### PR TITLE
Small Tweaks

### DIFF
--- a/packages/eslint-plugin/configs/jest.js
+++ b/packages/eslint-plugin/configs/jest.js
@@ -6,5 +6,8 @@ module.exports = {
     ...recomended.extends,
     'plugin:jest/recommended',
     'plugin:react/recommended'
-  ]
+  ],
+  rules: {
+    'jest/valid-expect': 'off'
+  }
 }

--- a/packages/eslint-plugin/configs/jest.js
+++ b/packages/eslint-plugin/configs/jest.js
@@ -1,0 +1,10 @@
+const recomended = require('./recomended');
+
+module.exports = {
+  ...recomended,
+  extends: [
+    ...recomended.extends,
+    'plugin:jest/recommended',
+    'plugin:react/recommended'
+  ]
+}

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -8,6 +8,7 @@ module.exports = {
   ],
   rules: {
     ...recomended.rules,
+    "react/display-name": "off",
     "react/prop-types": "off",
     "no-use-before-define": "off",
     "jsx-quotes": [

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -8,14 +8,14 @@ module.exports = {
   ],
   rules: {
     ...recomended.rules,
-    "react/display-name": "off",
-    "react/prop-types": "off",
-    "no-use-before-define": "off",
-    "jsx-quotes": [
-      "error",
-      "prefer-single"
+    '@typescript-eslint/no-use-before-define': 'error',
+    'jsx-quotes': [
+      'error',
+      'prefer-single'
     ],
-    "@typescript-eslint/no-use-before-define": "error"
+    'no-use-before-define': 'off',
+    'react/display-name': 'off',
+    'react/prop-types': 'off'
   },
   settings: {
     react: {

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -15,6 +15,29 @@ module.exports = {
     ],
     'no-use-before-define': 'off',
     'react/display-name': 'off',
+    'react/function-component-definition': ['error', {
+      'namedComponents': 'arrow-function',
+      'unnamedComponents': 'arrow-function'
+    }],
+    'react/jsx-first-prop-new-line': [
+      'error',
+      'multiline-multiprop'
+    ],
+    'react/jsx-tag-spacing': ['error', {
+      'closingSlash': 'never',
+      'beforeSelfClosing': 'always',
+      'afterOpening': 'never',
+      'beforeClosing': 'never'
+    }],
+    'react/jsx-wrap-multilines': ['error', {
+      'declaration': 'parens-new-line',
+      'assignment': 'parens-new-line',
+      'return': 'parens-new-line',
+      'arrow': 'parens-new-line',
+      'condition': 'parens-new-line',
+      'logical': 'parens-new-line',
+      'prop': 'parens-new-line'
+    }],
     'react/prop-types': 'off'
   },
   settings: {

--- a/packages/eslint-plugin/configs/recomended.js
+++ b/packages/eslint-plugin/configs/recomended.js
@@ -59,6 +59,7 @@ module.exports = {
     }],
     '@typescript-eslint/no-unused-vars': 'error',
     'curly': ['error', 'all'],
-    'brace-style': ['error', '1tbs']
+    'brace-style': ['error', '1tbs'],
+    'quote-props': ['error', 'consistent']
   }
 };

--- a/packages/eslint-plugin/configs/recomended.js
+++ b/packages/eslint-plugin/configs/recomended.js
@@ -11,7 +11,6 @@ module.exports = {
     project: './tsconfig.json'
   },
   extends: [
-    'plugin:jest/recommended',
     'semistandard',
     'plugin:@typescript-eslint/recommended'
   ],

--- a/packages/eslint-plugin/configs/recomended.js
+++ b/packages/eslint-plugin/configs/recomended.js
@@ -19,21 +19,17 @@ module.exports = {
     '@dxos'
   ],
   rules: {
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-non-null-assertion': 'off',
-    '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-floating-promises': 'error',
-    'no-void': [
-      'error',
-      {
-        allowAsStatement: true
-      }
-    ],
-    'no-useless-constructor': 'off',
-    '@typescript-eslint/no-useless-constructor': ['error'],
-    '@typescript-eslint/ban-types': 'off',
     '@dxos/header': 'error',
+    '@typescript-eslint/ban-types': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-empty-function': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-useless-constructor': ['error'],
+    'curly': ['error', 'all'],
+    'brace-style': ['error', '1tbs'],
     'import/order': ['error', {
       pathGroups: [
         {
@@ -57,11 +53,15 @@ module.exports = {
         order: 'asc'
       }
     }],
-    '@typescript-eslint/no-unused-vars': 'error',
-    'curly': ['error', 'all'],
-    'brace-style': ['error', '1tbs'],
-    'quote-props': ['error', 'consistent'],
     'multiline-ternary': 'off',
-    'no-unused-expressions': 'off'
+    'no-unused-expressions': 'off',
+    'no-useless-constructor': 'off',
+    'no-void': [
+      'error',
+      {
+        allowAsStatement: true
+      }
+    ],
+    'quote-props': ['error', 'consistent']
   }
 };

--- a/packages/eslint-plugin/configs/recomended.js
+++ b/packages/eslint-plugin/configs/recomended.js
@@ -38,7 +38,7 @@ module.exports = {
     'import/order': ['error', {
       pathGroups: [
         {
-          pattern: '@material-ui/**',
+          pattern: '@{mui,material-ui}/**',
           group: 'external',
           position: 'after'
         },
@@ -48,7 +48,7 @@ module.exports = {
           position: 'before'
         }
       ],
-      pathGroupsExcludedImportTypes: ['@{dxos,wirelineio}/**', '@material-ui/**'],
+      pathGroupsExcludedImportTypes: ['@{dxos,wirelineio}/**', '@{mui,material-ui}/**'],
       'newlines-between': 'always',
       groups: [
         ['builtin', 'external'],

--- a/packages/eslint-plugin/configs/recomended.js
+++ b/packages/eslint-plugin/configs/recomended.js
@@ -60,6 +60,8 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': 'error',
     'curly': ['error', 'all'],
     'brace-style': ['error', '1tbs'],
-    'quote-props': ['error', 'consistent']
+    'quote-props': ['error', 'consistent'],
+    'multiline-ternary': 'off',
+    'no-unused-expressions': 'off'
   }
 };


### PR DESCRIPTION
1. Include `mui` with the `material-ui` group
2. Factor out the jest plugin, many packages are no longer using jest and if it isn't installed it breaks eslint in VS Code
3. Enforce consistent quotes in objects